### PR TITLE
EXTINF tags need to be in floating-point format to work with AWS Elemental MediaConvert

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -884,7 +884,7 @@ impl MediaSegment {
             writeln!(w, "{}", unknown_tag)?;
         }
 
-        write!(w, "#EXTINF:{},", self.duration)?;
+        write!(w, "#EXTINF:{:.3},", self.duration)?;
 
         if let Some(ref v) = self.title {
             writeln!(w, "{}", v)?;


### PR DESCRIPTION
AWS Elemental MediaConvert rejects playlists with EXTINF tags that are not in floating point format. When m3u8 MediaSegment self.duration is an exact number without trailing decimals, writeln cuts off the decimal places and prints it like an integer.

This change forces writeln to always write it in a consistent format.